### PR TITLE
Batch supports the update option

### DIFF
--- a/index.js
+++ b/index.js
@@ -441,6 +441,7 @@ class Batch {
     this.onseq = this.options.onseq || noop
     this.appending = null
     this.isSnapshot = this.feed !== this.tree.feed
+    this.shouldUpdate = this.options.update !== false
     this.encoding = {
       key: options.keyEncoding ? codecs(options.keyEncoding) : tree.keyEncoding,
       value: options.valueEncoding ? codecs(options.valueEncoding) : tree.valueEncoding
@@ -471,7 +472,7 @@ class Batch {
         }))
       }
     }
-    if (this.tree._checkout === 0 && (opts && opts.update) !== false) await this.feed.update()
+    if (this.tree._checkout === 0 && this.shouldUpdate) await this.feed.update()
     if (this.version < 2) return null
     return (await this.getBlock(this.version - 1, opts)).getTreeNode(0)
   }

--- a/index.js
+++ b/index.js
@@ -461,8 +461,7 @@ class Batch {
     return Math.max(1, this.tree._checkout ? this.tree._checkout : this.feed.length + this.length)
   }
 
-  async getRoot (ensureHeader, opts) {
-    opts = { ...opts, ...this.options }
+  async getRoot (ensureHeader) {
     await this.ready()
     if (ensureHeader) {
       if (this.feed.length === 0 && this.feed.writable && !this.tree.readonly) {
@@ -474,19 +473,19 @@ class Batch {
     }
     if (this.tree._checkout === 0 && this.shouldUpdate) await this.feed.update()
     if (this.version < 2) return null
-    return (await this.getBlock(this.version - 1, opts)).getTreeNode(0)
+    return (await this.getBlock(this.version - 1)).getTreeNode(0)
   }
 
   async getKey (seq) {
     return (await this.getBlock(seq)).key
   }
 
-  async getBlock (seq, opts = this.options) {
+  async getBlock (seq) {
     if (this.rootSeq === 0) this.rootSeq = seq
     let b = this.blocks && this.blocks.get(seq)
     if (b) return b
     this.onseq(seq)
-    const entry = await this.feed.get(seq, { ...opts, valueEncoding: Node })
+    const entry = await this.feed.get(seq, { ...this.options, valueEncoding: Node })
     if (entry === null) throw new Error('Block not available locally')
     b = new BlockEntry(seq, this, entry)
     if (this.blocks && (this.blocks.size - this.length) < 128) this.blocks.set(seq, b)

--- a/iterators/history.js
+++ b/iterators/history.js
@@ -27,10 +27,10 @@ module.exports = class HistoryIterator {
 
     if (this.reverse) {
       if (this.lt <= 1) return null
-      return final(await this.batch.getBlock(--this.lt, this.options), this.encoding)
+      return final(await this.batch.getBlock(--this.lt), this.encoding)
     }
 
-    return final(await this.batch.getBlock(this.gte++, this.options), this.encoding)
+    return final(await this.batch.getBlock(this.gte++), this.encoding)
   }
 
   close () {


### PR DESCRIPTION
Previously, we would pass `update: false` directly to `batch.get(...)`, but it makes more sense to set this option at the batch-level.