### PR TITLE
Add isHyperbee

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,3 +272,9 @@ Current version.
 #### `await db.ready()`
 
 Makes sure internal state is loaded. Call this once before checking the version if you haven't called any of the other APIs.
+
+#### `await Hyperbee.isHyperbee(core, opts?)`
+
+Returns true if the core contains a hyperbee, false otherwise.
+
+Queries the core, so ensure it is available and has updated length before calling this.

--- a/index.js
+++ b/index.js
@@ -426,12 +426,12 @@ class Hyperbee {
     return this.feed.close()
   }
 
-  static async isHyperbee (core) {
+  static async isHyperbee (core, opts) {
     await core.ready()
 
     if (core.length === 0) return false
 
-    const blk0 = await core.get(0)
+    const blk0 = await core.get(0, opts)
     try {
       return Header.decode(blk0).protocol === 'hyperbee'
     } catch (err) { // undecodable

--- a/index.js
+++ b/index.js
@@ -428,7 +428,6 @@ class Hyperbee {
 
   static async isHyperbee (core) {
     await core.ready()
-    await core.update()
 
     if (core.length === 0) return false
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const codecs = require('codecs')
 const { Readable } = require('streamx')
 const mutexify = require('mutexify/promise')
 const b4a = require('b4a')
+const safetyCatch = require('safety-catch')
 
 const RangeIterator = require('./iterators/range')
 const HistoryIterator = require('./iterators/history')
@@ -423,6 +424,21 @@ class Hyperbee {
 
   close () {
     return this.feed.close()
+  }
+
+  static async isHyperbee (core) {
+    await core.ready()
+    await core.update()
+
+    if (core.length === 0) return false
+
+    const blk0 = await core.get(0)
+    try {
+      return Header.decode(blk0).protocol === 'hyperbee'
+    } catch (err) { // undecodable
+      safetyCatch(err)
+      return false
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "codecs": "^3.0.0",
     "mutexify": "^1.4.0",
     "protocol-buffers-encodings": "^1.2.0",
+    "safety-catch": "^1.0.2",
     "streamx": "^2.12.4"
   },
   "devDependencies": {

--- a/test/all.js
+++ b/test/all.js
@@ -1,6 +1,6 @@
 const test = require('brittle')
 const b4a = require('b4a')
-const { create, collect } = require('./helpers')
+const { create, collect, createCore } = require('./helpers')
 
 const Hyperbee = require('..')
 
@@ -440,4 +440,27 @@ test('get header out', async function (t) {
   await db.put('hi', 'ho')
   const h = await db.getHeader()
   t.is(h.protocol, 'hyperbee')
+})
+
+test('isHyperbee is false for empty hypercore', async function (t) {
+  const feed = createCore()
+  t.absent(await Hyperbee.isHyperbee(feed))
+})
+
+test('isHyperbee is false for non-empty hypercore', async function (t) {
+  const feed = createCore()
+  await feed.append('something')
+  t.absent(await Hyperbee.isHyperbee(feed))
+})
+
+test('isHyperbee is false for hypercore with 1st entry hyperbee', async function (t) {
+  const feed = createCore()
+  await feed.append('hyperbee')
+  t.absent(await Hyperbee.isHyperbee(feed))
+})
+
+test('isHyperbee is true for feed of actual hyperbee', async function (t) {
+  const db = create()
+  await db.put('hi', 'ho') // Adds the header on the first put
+  t.ok(await Hyperbee.isHyperbee(db.feed))
 })

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -7,7 +7,8 @@ module.exports = {
   createRange,
   insertRange,
   rangeify,
-  collect
+  collect,
+  createCore
 }
 
 function collect (stream) {
@@ -71,4 +72,8 @@ function create (opts) {
   opts = { keyEncoding: 'utf-8', valueEncoding: 'utf-8', ...opts }
   const feed = new Hypercore(require('random-access-memory'))
   return new Hyperbee(feed, opts)
+}
+
+function createCore () {
+  return new Hypercore(require('random-access-memory'))
 }


### PR DESCRIPTION
Note: this test flags some hyperbees which are usable as invalid. It happens if they are created from cores to which had already been pushed. Not sure what the intended behaviour is there--we could check `isHyperbee(this)`  in `ready()`, but it seems like a big change to suddenly disallow the below:

```

import Hypercore from 'hypercore'
import ram from 'random-access-memory'
import Hyperbee from 'hyperbee'

const core = new Hypercore(ram)
await core.ready()
await core.append('Random stuff')

const bee = new Hyperbee(core)
await bee.ready()
await bee.put('This is', 'okay?')

console.log((await core.get(0)).toString()) // 'Random stuff'
console.log((await bee.get('This is')).value.toString()) // 'okay?'

console.log(await bee.getHeader()) // This crashes with `Error: Decoded message is not valid`

```