### PR TITLE
Alias bee.core to bee.feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install hyperbee
 
 ``` js
 const Hyperbee = require('hyperbee')
-const db = new Hyperbee(feed, {
+const db = new Hyperbee(core, {
   keyEncoding: 'utf-8', // can be set to undefined (binary), utf-8, ascii or and abstract-encoding
   valueEncoding: 'binary' // same options as above
 })
@@ -48,7 +48,7 @@ feed is downloaded to satisfy your queries.
 
 ## API
 
-#### `const db = new Hyperbee(feed, [options])`
+#### `const db = new Hyperbee(core, [options])`
 
 Make a new Hyperbee instance. `feed` should be a [Hypercore](https://github.com/holepunchto/hypercore).
 
@@ -82,7 +82,7 @@ You have the option to pass a `cas` function as an option to `put` that controls
 
 ```js
 const cas = (prev, next) => prev.value !== next.value
-const db = new Hyperbee(feed, { keyEncoding: 'utf8', valueEncoding: 'utf8' })
+const db = new Hyperbee(core, { keyEncoding: 'utf8', valueEncoding: 'utf8' })
 await db.put('key', 'value')
 console.log(await db.get('key')) // { seq: 1, key: 'key', value: 'value' }
 await db.put('key', 'value', { cas })
@@ -113,7 +113,7 @@ You can pass a `cas` function as an option to `del` that controls whether the `d
 
 ```js
 const cas = (prev) => prev.value === 'value*'
-const db = new Hyperbee(feed, { keyEncoding: 'utf8', valueEncoding: 'utf8' })
+const db = new Hyperbee(core, { keyEncoding: 'utf8', valueEncoding: 'utf8' })
 await db.put('key', 'value')
 console.log(await db.get('key')) // { seq: 1, key: 'key', value: 'value' }
 await db.del('key', { cas })

--- a/index.js
+++ b/index.js
@@ -272,6 +272,7 @@ class BatchEntry extends BlockEntry {
 class Hyperbee {
   constructor (feed, opts = {}) {
     this.feed = feed
+    this.core = feed
 
     this.keyEncoding = opts.keyEncoding ? codecs(opts.keyEncoding) : null
     this.valueEncoding = opts.valueEncoding ? codecs(opts.valueEncoding) : null
@@ -430,6 +431,7 @@ class Batch {
   constructor (tree, feed, batchLock, cache, options = {}) {
     this.tree = tree
     this.feed = feed
+    this.core = feed
     this.blocks = cache ? new Map() : null
     this.autoFlush = !batchLock
     this.rootSeq = 0

--- a/index.js
+++ b/index.js
@@ -271,6 +271,7 @@ class BatchEntry extends BlockEntry {
 
 class Hyperbee {
   constructor (feed, opts = {}) {
+    // this.feed is now deprecated, and will be this.core going forward
     this.feed = feed
     this.core = feed
 
@@ -430,6 +431,7 @@ class Hyperbee {
 class Batch {
   constructor (tree, feed, batchLock, cache, options = {}) {
     this.tree = tree
+    // this.feed is now deprecated, and will be this.core going forward
     this.feed = feed
     this.core = feed
     this.blocks = cache ? new Map() : null


### PR DESCRIPTION
We refer to Hypercore as "cores" everywhere else, so we should do the same here.