### PR TITLE
Make isHyperbee wait or return null for empty core

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,10 @@ Makes sure internal state is loaded. Call this once before checking the version 
 
 #### `await Hyperbee.isHyperbee(core, opts?)`
 
-Returns true if the core contains a hyperbee, false otherwise.
+Returns true if the core contains a hyperbee, false if it does not, or null if it is not yet known.
 
-Queries the core, so ensure it is available and has updated length before calling this.
+Null is only returned when the first block could not be obtained AND an option to make it return early was set,
+such as `wait: false` or `timeout: someTimeout` (see the documentation for `hypercore.get`).
+
+The default behaviour is to wait until the first block is available (returning either true or false).
+

--- a/README.md
+++ b/README.md
@@ -275,10 +275,11 @@ Makes sure internal state is loaded. Call this once before checking the version 
 
 #### `await Hyperbee.isHyperbee(core, opts?)`
 
-Returns true if the core contains a hyperbee, false if it does not, or null if it is not yet known.
+Returns true if the core contains a hyperbee, false otherwise.
 
-Null is only returned when the first block could not be obtained AND an option to make it return early was set,
-such as `wait: false` or `timeout: someTimeout` (see the documentation for `hypercore.get`).
-
-The default behaviour is to wait until the first block is available (returning either true or false).
+Throws if the first block could not be loaded.
+This can only happen when the likes of `wait: false` or `timeout: someTimeout` are set
+(see the documentation for `hypercore.get`).
+The default behaviour is to wait until the first block is available
+(thereafter returning either true or false).
 

--- a/index.js
+++ b/index.js
@@ -435,7 +435,7 @@ class Hyperbee {
     await core.ready()
 
     const blk0 = await core.get(0, opts)
-    if (blk0 === null) throw new Error('Block0 not available locally')
+    if (blk0 === null) throw new Error('Block 0 not available locally')
 
     try {
       return Header.decode(blk0).protocol === 'hyperbee'

--- a/index.js
+++ b/index.js
@@ -435,7 +435,7 @@ class Hyperbee {
     await core.ready()
 
     const blk0 = await core.get(0, opts)
-    if (!blk0) return null
+    if (blk0 === null) throw new Error('Block0 not available locally')
 
     try {
       return Header.decode(blk0).protocol === 'hyperbee'

--- a/index.js
+++ b/index.js
@@ -434,9 +434,9 @@ class Hyperbee {
   static async isHyperbee (core, opts) {
     await core.ready()
 
-    if (core.length === 0) return false
-
     const blk0 = await core.get(0, opts)
+    if (!blk0) return null
+
     try {
       return Header.decode(blk0).protocol === 'hyperbee'
     } catch (err) { // undecodable

--- a/test/all.js
+++ b/test/all.js
@@ -442,21 +442,21 @@ test('get header out', async function (t) {
   t.is(h.protocol, 'hyperbee')
 })
 
-test('isHyperbee is false for empty hypercore', async function (t) {
+test('isHyperbee is null for empty hypercore and wait false', async function (t) {
   const feed = createCore()
-  t.absent(await Hyperbee.isHyperbee(feed))
+  t.is(await Hyperbee.isHyperbee(feed, { wait: false }), null)
 })
 
 test('isHyperbee is false for non-empty hypercore', async function (t) {
   const feed = createCore()
   await feed.append('something')
-  t.absent(await Hyperbee.isHyperbee(feed))
+  t.is(await Hyperbee.isHyperbee(feed), false)
 })
 
 test('isHyperbee is false for hypercore with 1st entry hyperbee', async function (t) {
   const feed = createCore()
   await feed.append('hyperbee')
-  t.absent(await Hyperbee.isHyperbee(feed))
+  t.is(await Hyperbee.isHyperbee(feed), false)
 })
 
 test('isHyperbee is true for feed of actual hyperbee', async function (t) {

--- a/test/all.js
+++ b/test/all.js
@@ -444,7 +444,7 @@ test('get header out', async function (t) {
 
 test('isHyperbee throws for empty hypercore and wait false', async function (t) {
   const feed = createCore()
-  await t.exception(Hyperbee.isHyperbee(feed, { wait: false }), 'Block0 not available locally')
+  await t.exception(Hyperbee.isHyperbee(feed, { wait: false }), 'Block 0 not available locally')
 })
 
 test('isHyperbee is false for non-empty hypercore', async function (t) {

--- a/test/all.js
+++ b/test/all.js
@@ -442,9 +442,9 @@ test('get header out', async function (t) {
   t.is(h.protocol, 'hyperbee')
 })
 
-test('isHyperbee is null for empty hypercore and wait false', async function (t) {
+test('isHyperbee throws for empty hypercore and wait false', async function (t) {
   const feed = createCore()
-  t.is(await Hyperbee.isHyperbee(feed, { wait: false }), null)
+  await t.exception(Hyperbee.isHyperbee(feed, { wait: false }), 'Block0 not available locally')
 })
 
 test('isHyperbee is false for non-empty hypercore', async function (t) {


### PR DESCRIPTION
I think my initial implementation of isHyperbee was wrong, because I didn't fully understand what the patterns with the `wait` (or `timeout`) options were.

Previous:
If empty core => return false
New:
If empty core => Wait set ? return null : wait on first block

Feel free to close if the previous behaviour was the expected one--I can easily get around this.

Still not very happy with this solution, since it's a boolean check with 3 possible outcomes, which is super weird. But I don't see another way to support the ready() pattern of hyperdrive if it depends on isHyperbee: 

```
  async _open () {
    await this._doFancySetup({wait: false})

    if(!this.setupDone) {
        this._doFancySetup()
    }
    ...
  }

  async _doFancySetup (opts) {
    const isBee = await Hyperbee.isHyperbee(this._core, opts)
    if (isBee === null) return
    // Do stuff
    this.setupDone = true

  }
```