### PR TITLE
Use bee's state at diffStream creation time

### DIFF
--- a/index.js
+++ b/index.js
@@ -355,12 +355,17 @@ class Hyperbee {
 
   createDiffStream (right, opts) {
     if (typeof right === 'number') right = this.checkout(Math.max(1, right))
-    const snapshot = right.version > this.version ? right.feed.snapshot() : this.feed.snapshot()
+    // Ensure the bee at the time of creating the diff stream is used
+    // rather than the bee at the time of beginning to consume the diff stream
+    // TODO: same for right if passed a bee instead of version nr?
+    const left = this.snapshot()
+
+    const snapshot = right.version > this.version ? right.feed.snapshot() : left.feed.snapshot()
 
     const keyEncoding = opts && opts.keyEncoding ? codecs(opts.keyEncoding) : this.keyEncoding
     if (keyEncoding) opts = encRange(keyEncoding, { ...opts, sub: this._sub })
 
-    return iteratorToStream(new DiffIterator(new Batch(this, snapshot, null, false, opts), new Batch(right, snapshot, null, false, opts), opts))
+    return iteratorToStream(new DiffIterator(new Batch(left, snapshot, null, false, opts), new Batch(right, snapshot, null, false, opts), opts))
   }
 
   get (key, opts) {

--- a/index.js
+++ b/index.js
@@ -340,7 +340,7 @@ class Hyperbee {
       opts = encRange(keyEncoding, { ...opts, sub: this._sub })
     }
 
-    const ite = new RangeIterator(new Batch(this, this.feed.snapshot(), null, false, opts), null, opts)
+    const ite = new RangeIterator(new Batch(this.snapshot(), this.feed.snapshot(), null, false, opts), null, opts)
     return ite
   }
 
@@ -350,14 +350,16 @@ class Hyperbee {
 
   createHistoryStream (opts) {
     const session = (opts && opts.live) ? this.feed.session() : this.feed.snapshot()
-    return iteratorToStream(new HistoryIterator(new Batch(this, session, null, false, opts), opts))
+    return iteratorToStream(new HistoryIterator(new Batch(this.snapshot(), session, null, false, opts), opts))
   }
 
   createDiffStream (right, opts) {
     if (typeof right === 'number') right = this.checkout(Math.max(1, right))
+
     // Ensure the bee at the time of creating the diff stream is used
     // rather than the bee at the time of beginning to consume the diff stream
-    // TODO: same for right if passed a bee instead of version nr?
+    // TODO: clean fix with upstream change in hypercore, so the db.feed snapshots
+    // snap fully at creation time (currently not possible)
     const left = this.snapshot()
 
     const snapshot = right.version > this.version ? right.feed.snapshot() : left.feed.snapshot()

--- a/test/diff.js
+++ b/test/diff.js
@@ -138,8 +138,9 @@ test('diff key encoding option', async function (t) {
   t.is(entries.length, 1)
 })
 
-test('diff on bee being appended to takes create-time snapshot', async function (t) {
-  const db = await create()
+test('streams on bee being appended to take create-time snapshot', async function (t) {
+  t.plan(3)
+  const db = create()
 
   let entrySpammer
   try {
@@ -148,26 +149,30 @@ test('diff on bee being appended to takes create-time snapshot', async function 
 
     await new Promise((resolve) => setTimeout(resolve, 1))
 
-    const s1 = db.createDiffStream(1)
-    const s2 = db.createDiffStream(1)
+    const funs = [
+      db => db.createHistoryStream(),
+      db => db.createDiffStream(1),
+      db => db.createReadStream()
+    ]
 
-    // DEVNOTE: this test is probably non-deterministic
-    // (can have different behaviour depending on the CPU speed)
-    // Unsure how to make it deterministic
-    // To trigger the race condition, both the entrySpammer, the timeout
-    // and the manual background-puts seem to be required
-    db.put('more')
-    db.put('background confusion')
+    for (const fun of funs) {
+      const s1 = fun(db)
+      const s2 = fun(db)
 
-    const s1Added = []
-    const s2Added = []
-    for await (const elem of s1) { s1Added.push(elem) }
-    for await (const elem of s2) { s2Added.push(elem) }
-    t.is(s1Added.length, s2Added.length)
+      // DEVNOTE: this test is probably non-deterministic
+      // (can have different behaviour depending on the CPU speed)
+      // To trigger the race condition, both the entrySpammer, the timeout
+      // and the manual background-puts seem to be required
+      db.put('more')
+      db.put('background confusion')
+
+      const s1Added = []
+      const s2Added = []
+      for await (const elem of s1) { s1Added.push(elem) }
+      for await (const elem of s2) { s2Added.push(elem) }
+      t.is(s1Added.length, s2Added.length)
+    }
   } finally {
-    // TODO: is the try-finally needed?
-    // interval seems to be cleaned up in case of an error anyway
-    // but unsure if that's guaranteed
     if (entrySpammer) clearInterval(entrySpammer)
   }
 })


### PR DESCRIPTION
The behaviour of the streams is unintuitive: the resulting stream can include entries not yet present at the time of creating the stream (no snapshot is taken).
A straightforward solution: use snapshots when creating the stream. I think this conforms more to user expectation: when creating a diffStream, I expect the diffStream at the time I asked for it, not the diffStream of some future state of the bee.

Simple example:
```
    const s1 = db.createDiffStream(1)
    const s2 = db.createDiffStream(1)

    const s1Added = []
    const s2Added = []
    for await (const elem of s1) { s1Added.push(elem) }
    for await (const elem of s2) { s2Added.push(elem) }

    // s2 can contain more elements than s2 in certain cases
```
See the test for how to trigger the race condition (it's tricky)

This applies to diffStream, readStream and historyStream. Holding off on implementing the fix for readStream and historyStream until sure the proposed solution is good.

