### PR TITLE
Support encoded checkout

### DIFF
--- a/index.js
+++ b/index.js
@@ -382,15 +382,15 @@ class Hyperbee {
     return b.del(key, opts)
   }
 
-  checkout (version) {
+  checkout (version, opts = {}) {
     return new Hyperbee(this.feed.snapshot(), {
       _ready: this.ready(),
       _sub: false,
       sep: this.sep,
       prefix: this.prefix,
       checkout: version,
-      keyEncoding: this.keyEncoding,
-      valueEncoding: this.valueEncoding,
+      keyEncoding: opts.keyEncoding || this.keyEncoding,
+      valueEncoding: opts.keyEncoding || this.valueEncoding,
       extension: this.extension !== null ? this.extension : false
     })
   }

--- a/index.js
+++ b/index.js
@@ -395,8 +395,8 @@ class Hyperbee {
     })
   }
 
-  snapshot () {
-    return this.checkout(this.version)
+  snapshot (opts) {
+    return this.checkout(this.version, opts)
   }
 
   sub (prefix, opts = {}) {

--- a/index.js
+++ b/index.js
@@ -390,7 +390,7 @@ class Hyperbee {
       prefix: this.prefix,
       checkout: version,
       keyEncoding: opts.keyEncoding || this.keyEncoding,
-      valueEncoding: opts.keyEncoding || this.valueEncoding,
+      valueEncoding: opts.valueEncoding || this.valueEncoding,
       extension: this.extension !== null ? this.extension : false
     })
   }

--- a/test/all.js
+++ b/test/all.js
@@ -469,16 +469,20 @@ test('supports encodings in checkout', async function (t) {
   const db = create()
   await db.put('hi', 'there')
 
-  const checkout = db.checkout(db.version, { keyEncoding: 'binary', valueEncoding: 'binary' })
-  t.alike(await db.get('hi'), { seq: 1, key: 'hi', value: 'there' }) // sanity check
-  t.alike(await checkout.get('hi'), { seq: 1, key: b4a.from('hi'), value: b4a.from('there') })
+  const checkout1 = db.checkout(db.version, { keyEncoding: 'binary' })
+  const checkout2 = db.checkout(db.version, { valueEncoding: 'binary' })
+
+  t.alike(await checkout1.get('hi'), { seq: 1, key: b4a.from('hi'), value: 'there' })
+  t.alike(await checkout2.get('hi'), { seq: 1, key: 'hi', value: b4a.from('there') })
 })
 
 test('supports encodings in snapshot', async function (t) {
   const db = create()
   await db.put('hi', 'there')
 
-  const snap = db.snapshot({ keyEncoding: 'binary', valueEncoding: 'binary' })
-  t.alike(await db.get('hi'), { seq: 1, key: 'hi', value: 'there' }) // sanity check
-  t.alike(await snap.get('hi'), { seq: 1, key: b4a.from('hi'), value: b4a.from('there') })
+  const snap1 = db.snapshot({ keyEncoding: 'binary' })
+  const snap2 = db.snapshot({ valueEncoding: 'binary' })
+
+  t.alike(await snap1.get('hi'), { seq: 1, key: b4a.from('hi'), value: 'there' })
+  t.alike(await snap2.get('hi'), { seq: 1, key: 'hi', value: b4a.from('there') })
 })

--- a/test/all.js
+++ b/test/all.js
@@ -464,3 +464,12 @@ test('isHyperbee is true for feed of actual hyperbee', async function (t) {
   await db.put('hi', 'ho') // Adds the header on the first put
   t.ok(await Hyperbee.isHyperbee(db.feed))
 })
+
+test('supports encodings in checkout', async function (t) {
+  const db = create()
+  await db.put('hi', 'there')
+
+  const checkout = db.checkout(db.version, { keyEncoding: 'binary', valueEncoding: 'binary' })
+  t.alike(await db.get('hi'), { seq: 1, key: 'hi', value: 'there' })
+  t.alike(await checkout.get('hi'), { seq: 1, key: b4a.from('hi'), value: b4a.from('there') })
+})

--- a/test/all.js
+++ b/test/all.js
@@ -470,6 +470,15 @@ test('supports encodings in checkout', async function (t) {
   await db.put('hi', 'there')
 
   const checkout = db.checkout(db.version, { keyEncoding: 'binary', valueEncoding: 'binary' })
-  t.alike(await db.get('hi'), { seq: 1, key: 'hi', value: 'there' })
+  t.alike(await db.get('hi'), { seq: 1, key: 'hi', value: 'there' }) // sanity check
   t.alike(await checkout.get('hi'), { seq: 1, key: b4a.from('hi'), value: b4a.from('there') })
+})
+
+test('supports encodings in snapshot', async function (t) {
+  const db = create()
+  await db.put('hi', 'there')
+
+  const snap = db.snapshot({ keyEncoding: 'binary', valueEncoding: 'binary' })
+  t.alike(await db.get('hi'), { seq: 1, key: 'hi', value: 'there' }) // sanity check
+  t.alike(await snap.get('hi'), { seq: 1, key: b4a.from('hi'), value: b4a.from('there') })
 })


### PR DESCRIPTION
Note: opted to only pass key- and valueEncoding rather than passing through the `...opts` to the Hyperbee constructor because I'm not sure if it makes sense to support (all) other options. Can adapt