### PR TITLE
Use ready-resource for watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Watchers on subs and checkouts are not supported. Instead, use the range option 
 
 Waits until the watcher is loaded and detecting changes.
 
-`await watcher.destroy()`
+`await watcher.close()`
 
 Stops the watcher. You could also stop it by using `break` in the loop.
 

--- a/index.js
+++ b/index.js
@@ -921,8 +921,6 @@ class Watcher extends ReadyResource {
   }
 
   async next () {
-    if (!this.opened) await this.ready()
-
     try {
       return await this._next()
     } catch (err) {

--- a/index.js
+++ b/index.js
@@ -913,7 +913,7 @@ class Watcher extends ReadyResource {
   }
 
   async _waitForChanges () {
-    if (this.current.version < this.bee.version || this.closed) return
+    if (this.current.version < this.bee.version || this.closing) return
 
     await new Promise(resolve => {
       this._resolveOnChange = resolve
@@ -936,14 +936,14 @@ class Watcher extends ReadyResource {
     const release = await this._lock()
 
     try {
-      if (this.closed) return { value: undefined, done: true }
+      if (this.closing) return { value: undefined, done: true }
 
       if (!this.opened) await this.ready()
 
       while (true) {
         await this._waitForChanges()
 
-        if (this.closed) return { value: undefined, done: true }
+        if (this.closing) return { value: undefined, done: true }
 
         if (this.previous) await this.previous.close()
         this.previous = this.current.snapshot()

--- a/index.js
+++ b/index.js
@@ -986,8 +986,8 @@ class Watcher extends ReadyResource {
     release()
   }
 
-  async destroy () {
-    await this.close()
+  destroy () {
+    return this.close()
   }
 
   _closeSnapshots () {

--- a/index.js
+++ b/index.js
@@ -986,7 +986,6 @@ class Watcher extends ReadyResource {
     release()
   }
 
-  // For backward compat
   async destroy () {
     await this.close()
   }

--- a/test/watch.js
+++ b/test/watch.js
@@ -484,7 +484,7 @@ test('slow differ that gets destroyed should not throw', async function (t) {
     return {
       async * [Symbol.asyncIterator] () {
         while (true) {
-          if (watcher.closed) throw new Error('Custom stream was destroyed')
+          if (watcher.closing) throw new Error('Custom stream was destroyed')
           await eventFlush()
         }
       },


### PR DESCRIPTION
This is not just a refactor, the behaviour changes subtly.

I think that in the previous version there was a race condition on calling next before the watcher was ready, but it never triggered. I had to add `if (!this.opened) await this.ready()` to `Watcher.next()` to make the tests pass. I think `next()` is the only entrypoint, so should be fine to just add this check there.

Also in `next()`:       `if (this.closed) return { value: undefined, done: true } ` had to change to `if (this.closing)`, because `this.closing` and `this.closed` are no longer set in the same tick now that we're using ready resource. Likewise for the test I changed.

There's another method where I'm not sure if it should also change to `closing`: 
```
  async _waitForChanges () {
    if (this.current.version < this.bee.version || this.closed) return

    await new Promise(resolve => {
      this._resolveOnChange = resolve
    })
  }
```


Another subtle change which I don't think will matter is that `ReadyResource.close()` does not wait until the Watcher is open if it's not already opening:
`  if (self.opened === false && self.opening !== null) await self.opening`

But the previous `watcher._destroy()` did wait in that case: `if (!this.opened) await this._opening.catch(safetyCatch)`



Note: `watcher.destroy()` is kept for backward compat, but if that's not needed, it would be cleaner to just remove it
