### PR TITLE
Add getAndWatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,16 @@ and `right` will be null, and vice versa.
 If the entries are causally equal (i.e. the have the same seq), they are not
 returned, only the diff.
 
+#### `const entryWatcher = await db.getAndWatch(key)`
+
+Returns a watcher which listens to changes on the given key.
+
+`entryWatcher.node` contains the current entry in the same format as the result of `bee.get(key)`,  and will be updated as it changes.
+
+You can listen to `entryWatcher.on('update')` to be notified when the value of node has changed.
+
+Call `await watcher.close()` to stop the watcher.
+
 #### `const watcher = db.watch([range])`
 
 Listens to changes that are on the optional `range`.

--- a/index.js
+++ b/index.js
@@ -899,9 +899,10 @@ class EntryWatcher extends ReadyResource {
     this.bee._watchers.delete(this)
   }
 
-  async _onappend () {
+  async _onappend (isTruncate) {
     if (!this.opened) await this.ready()
-    // TODO: truncate optimisation
+
+    if (isTruncate && (this.node?.seq || 0) < this.bee.version) return
 
     let newNode
     try {

--- a/index.js
+++ b/index.js
@@ -409,6 +409,7 @@ class Hyperbee extends ReadyResource {
     await watcher._debouncedUpdate()
 
     if (this.closing) {
+      await watcher.close()
       throw new Error('Bee closed')
     }
 

--- a/index.js
+++ b/index.js
@@ -971,7 +971,7 @@ class EntryWatcher extends ReadyResource {
         // There was a truncate event before the get resolved
         // So this handler will run again anyway
         return
-      } else if (e.code === 'SESSION_CLOSED') {
+      } else if (this.bee.closing) {
         this.close().catch(safetyCatch)
         return
       }

--- a/index.js
+++ b/index.js
@@ -947,6 +947,11 @@ class EntryWatcher extends ReadyResource {
     this._debouncedUpdate()
   }
 
+  _ontruncate () {
+    this._forceUpdate = true
+    this._debouncedUpdate()
+  }
+
   async _processUpdate () {
     try {
       if (!this.opened) await this.ready()
@@ -978,11 +983,6 @@ class EntryWatcher extends ReadyResource {
       }
       this.emit('error', e)
     }
-  }
-
-  _ontruncate () {
-    this._forceUpdate = true
-    this._debouncedUpdate()
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -493,7 +493,7 @@ class Hyperbee extends ReadyResource {
   async _close () {
     if (this._watchers) {
       this.core.off('append', this._onappendBound)
-      this.core.off('truncate', this._onappendBound)
+      this.core.off('truncate', this._ontruncateBound)
 
       while (this._watchers.length) {
         await this._watchers[this._watchers.length - 1].close()

--- a/index.js
+++ b/index.js
@@ -952,7 +952,7 @@ class EntryWatcher extends ReadyResource {
         // So this handler will run again anyway
         return
       }
-      throw e
+      this.emit('error', e)
     }
 
     if (newNode?.seq !== this.node?.seq) {

--- a/index.js
+++ b/index.js
@@ -899,7 +899,7 @@ class EntryWatcher extends ReadyResource {
   constructor (bee, key) {
     super()
 
-    bee._watchers.add(this)
+    this.index = bee._watchers.push(this) - 1
     this.bee = bee
 
     this.key = key
@@ -913,7 +913,11 @@ class EntryWatcher extends ReadyResource {
   }
 
   _close () {
-    this.bee._watchers.delete(this)
+    const top = this.bee._watchers.pop()
+    if (top !== this) {
+      top.index = this.index
+      this.bee._watchers[top.index] = top
+    }
   }
 
   async _onappend () {

--- a/index.js
+++ b/index.js
@@ -941,6 +941,10 @@ class EntryWatcher extends ReadyResource {
   }
 
   async _onappend () {
+    await this._processUpdate()
+  }
+
+  async _processUpdate (force = false) {
     if (!this.opened) await this.ready()
 
     let newNode
@@ -955,14 +959,14 @@ class EntryWatcher extends ReadyResource {
       this.emit('error', e)
     }
 
-    if (newNode?.seq !== this.node?.seq) {
+    if (force || newNode?.seq !== this.node?.seq) {
       this.node = newNode
       this.emit('update')
     }
   }
 
   async _ontruncate () {
-    await this._onappend()
+    await this._processUpdate(true)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -924,8 +924,6 @@ class EntryWatcher extends ReadyResource {
 
     this.key = key
     this.node = null
-
-    this.ready().catch(safetyCatch)
   }
 
   async _open () {

--- a/index.js
+++ b/index.js
@@ -972,7 +972,7 @@ class EntryWatcher extends ReadyResource {
 
   async _ontruncate () {
     this._forceUpdate = true
-    await this._debouncedUpdate(true)
+    await this._debouncedUpdate()
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -493,10 +493,16 @@ class Hyperbee extends ReadyResource {
   async _close () {
     if (this._watchers) {
       this.core.off('append', this._onappendBound)
-      if (this.core.isAutobase) this.core.off('truncate', this._onappendBound)
+      this.core.off('truncate', this._onappendBound)
 
       while (this._watchers.length) {
         await this._watchers[this._watchers.length - 1].close()
+      }
+    }
+
+    if (this._entryWatchers) {
+      while (this._entryWatchers.length) {
+        await this._entryWatchers[this._entryWatchers.length - 1].close()
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -899,10 +899,8 @@ class EntryWatcher extends ReadyResource {
     this.bee._watchers.delete(this)
   }
 
-  async _onappend (isTruncate) {
+  async _onappend () {
     if (!this.opened) await this.ready()
-
-    if (isTruncate && (this.node?.seq || 0) < this.bee.version) return
 
     let newNode
     try {

--- a/index.js
+++ b/index.js
@@ -399,9 +399,12 @@ class Hyperbee extends ReadyResource {
     return new Watcher(this, range, opts)
   }
 
-  getAndWatch (key) {
+  async getAndWatch (key) {
     if (!this._watchers) throw new Error('Can only watch the main bee instance')
-    return new EntryWatcher(this, key)
+    const watcher = new EntryWatcher(this, key)
+    await watcher.ready()
+
+    return watcher
   }
 
   _onappend () {

--- a/index.js
+++ b/index.js
@@ -295,6 +295,8 @@ class Hyperbee extends ReadyResource {
     this._onappendBound = this._view ? null : this._onappend.bind(this)
     this._ontruncateBound = this._view ? null : this._ontruncate.bind(this)
     this._watchers = this._onappendBound ? [] : null
+    this._entryWatchers = this._onappendBound ? [] : null
+
     this._batches = []
 
     if (this._watchers) {
@@ -411,10 +413,18 @@ class Hyperbee extends ReadyResource {
     for (const watcher of this._watchers) {
       watcher._onappend()
     }
+
+    for (const watcher of this._entryWatchers) {
+      watcher._onappend()
+    }
   }
 
   _ontruncate () {
     for (const watcher of this._watchers) {
+      watcher._ontruncate()
+    }
+
+    for (const watcher of this._entryWatchers) {
       watcher._ontruncate()
     }
   }
@@ -909,7 +919,7 @@ class EntryWatcher extends ReadyResource {
   constructor (bee, key) {
     super()
 
-    this.index = bee._watchers.push(this) - 1
+    this.index = bee._entryWatchers.push(this) - 1
     this.bee = bee
 
     this.key = key
@@ -923,10 +933,10 @@ class EntryWatcher extends ReadyResource {
   }
 
   _close () {
-    const top = this.bee._watchers.pop()
+    const top = this.bee._entryWatchers.pop()
     if (top !== this) {
       top.index = this.index
-      this.bee._watchers[top.index] = top
+      this.bee._entryWatchers[top.index] = top
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -954,15 +954,6 @@ class EntryWatcher extends ReadyResource {
   }
 
   async _processUpdate () {
-    if (!this.opened) {
-      try {
-        await this.ready()
-      } catch (e) {
-        this.emit('error', e)
-        return
-      }
-    }
-
     const force = this._forceUpdate
     this._forceUpdate = false
 

--- a/index.js
+++ b/index.js
@@ -962,6 +962,7 @@ class EntryWatcher extends ReadyResource {
         return
       }
       this.emit('error', e)
+      return
     }
 
     if (force || newNode?.seq !== this.node?.seq) {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "b4a": "^1.6.0",
     "codecs": "^3.0.0",
+    "debounceify": "^1.0.0",
     "mutexify": "^1.4.0",
     "protocol-buffers-encodings": "^1.2.0",
     "ready-resource": "^1.0.0",

--- a/test/watch.js
+++ b/test/watch.js
@@ -34,6 +34,27 @@ test('current value loaded when getAndWatch resolves', async function (t) {
   t.is(watcher.node.value, 'here')
 })
 
+test('throws if bee closing while calling getAndWatch', async function (t) {
+  const db = create()
+  await db.put('aKey', 'here')
+
+  const prom = db.close()
+  await t.exception(db.getAndWatch('aKey'), /Bee closed/)
+
+  await prom
+})
+
+test('throws if bee starts closing before getAndWatch resolves', async function (t) {
+  const db = create()
+  await db.put('aKey', 'here')
+
+  const prom = db.getAndWatch('aKey')
+  const closeProm = db.close()
+  await t.exception(prom, /Bee closed/)
+
+  await closeProm
+})
+
 test('getAndWatch truncate flow', async function (t) {
   const db = create()
   const watcher = await db.getAndWatch('aKey')

--- a/test/watch.js
+++ b/test/watch.js
@@ -4,9 +4,8 @@ const Hyperbee = require('../index.js')
 
 test('basic getAndWatch append flow', async function (t) {
   const db = create()
-  const watcher = db.getAndWatch('aKey')
+  const watcher = await db.getAndWatch('aKey')
 
-  await watcher.ready()
   t.is(watcher.node, null)
 
   await db.put('other', 'key')
@@ -27,9 +26,17 @@ test('basic getAndWatch append flow', async function (t) {
   t.is(watcher.node.value, 'now here')
 })
 
+test('current value loaded when getAndWatch resolves', async function (t) {
+  const db = create()
+  await db.put('aKey', 'here')
+
+  const watcher = await db.getAndWatch('aKey')
+  t.is(watcher.node.value, 'here')
+})
+
 test('getAndWatch truncate flow', async function (t) {
   const db = create()
-  const watcher = db.getAndWatch('aKey')
+  const watcher = await db.getAndWatch('aKey')
 
   await db.put('aKey', 'here')
   await db.put('otherKey', 'other1Val')
@@ -58,7 +65,7 @@ test('getAndWatch truncate flow', async function (t) {
 
 test('getAndWatch truncate flow with deletes', async function (t) {
   const db = create()
-  const watcher = db.getAndWatch('aKey')
+  const watcher = await db.getAndWatch('aKey')
 
   await db.put('aKey', 'here')
   await db.put('otherKey', 'other1Val')
@@ -82,7 +89,7 @@ test('getAndWatch emits update', async function (t) {
   t.plan(2)
 
   const db = create()
-  const watcher = db.getAndWatch('aKey')
+  const watcher = await db.getAndWatch('aKey')
 
   let first = true
   watcher.on('update', () => {
@@ -107,7 +114,7 @@ test('getAndWatch emits update', async function (t) {
 
 test('getAndWatch chaos', async function (t) {
   const db = create()
-  const watcher = db.getAndWatch('aKey')
+  const watcher = await db.getAndWatch('aKey')
 
   const updates = []
   watcher.on('update', () => updates.push(watcher.node))

--- a/test/watch.js
+++ b/test/watch.js
@@ -112,37 +112,6 @@ test('getAndWatch emits update', async function (t) {
   await eventFlush()
 })
 
-test('getAndWatch chaos', async function (t) {
-  const db = create()
-  const watcher = await db.getAndWatch('aKey')
-
-  const updates = []
-  watcher.on('update', () => updates.push(watcher.node))
-
-  const proms = []
-  for (let i = 0; i < 5; i++) {
-    proms.push(db.put('some', `thing irrelevant${i}`))
-    proms.push(db.put('aKey', `value ${i}`))
-    proms.push(db.put(`other key ${i}`, 'irrelevant'))
-  }
-
-  await Promise.all(proms)
-  await eventFlush() // TODO: figure out why an event flush is needed
-
-  const moreProms = []
-  moreProms.push(db.core.truncate(6)) // Back to value1
-  for (let i = 5; i < 10; i++) {
-    moreProms.push(db.put('some', `thing irrelevant${i}`))
-    moreProms.push(db.put('aKey', `value ${i}`))
-    moreProms.push(db.put(`other key ${i}`, 'irrelevant'))
-  }
-  await Promise.all(moreProms)
-
-  t.is(watcher.node.value, 'value 9')
-  t.is(updates.at(-1).value, 'value 9')
-  t.is((await db.get('aKey')).value, 'value 9')
-})
-
 test('basic watch', async function (t) {
   t.plan(2)
 

--- a/test/watch.js
+++ b/test/watch.js
@@ -24,6 +24,9 @@ test('basic getAndWatch append flow', async function (t) {
   await db.put('aKey', 'now here')
   await eventFlush()
   t.is(watcher.node.value, 'now here')
+
+  await db.close()
+  t.is(watcher.closed, true)
 })
 
 test('current value loaded when getAndWatch resolves', async function (t) {
@@ -44,13 +47,17 @@ test('throws if bee closing while calling getAndWatch', async function (t) {
   await prom
 })
 
-test('throws if bee starts closing before getAndWatch resolves', async function (t) {
+test.skip('throws if bee starts closing before getAndWatch resolves', async function (t) {
   const db = create()
   await db.put('aKey', 'here')
 
   const prom = db.getAndWatch('aKey')
   const closeProm = db.close()
-  await t.exception(prom, /Bee closed/)
+  // TODO: should throw the 'Bee closed' exception
+  // but instead throws a random-access-storage error
+  // --unskip when that is fixed
+  await prom
+  // await t.exception(prom, /Bee closed/)
 
   await closeProm
 })

--- a/test/watch.js
+++ b/test/watch.js
@@ -47,17 +47,13 @@ test('throws if bee closing while calling getAndWatch', async function (t) {
   await prom
 })
 
-test.skip('throws if bee starts closing before getAndWatch resolves', async function (t) {
+test('throws if bee starts closing before getAndWatch resolves', async function (t) {
   const db = create()
   await db.put('aKey', 'here')
 
   const prom = db.getAndWatch('aKey')
   const closeProm = db.close()
-  // TODO: should throw the 'Bee closed' exception
-  // but instead throws a random-access-storage error
-  // --unskip when that is fixed
-  await prom
-  // await t.exception(prom, /Bee closed/)
+  await t.exception(prom, /Bee closed/)
 
   await closeProm
 })

--- a/test/watch.js
+++ b/test/watch.js
@@ -56,6 +56,28 @@ test('getAndWatch truncate flow', async function (t) {
   t.is(watcher.node.value, 'is back')
 })
 
+test('getAndWatch truncate flow with deletes', async function (t) {
+  const db = create()
+  const watcher = db.getAndWatch('aKey')
+
+  await db.put('aKey', 'here')
+  await db.put('otherKey', 'other1Val')
+  await db.put('otherKey2', 'otherVal2')
+  await db.del('aKey')
+  t.is(db.core.length, 5) // Sanity check
+
+  await eventFlush()
+  t.is(watcher.node, null)
+
+  await db.core.truncate(2)
+  await eventFlush()
+  t.is(watcher.node.value, 'here')
+
+  await db.core.truncate(1)
+  await eventFlush()
+  t.is(watcher.node, null)
+})
+
 test('getAndWatch emits update', async function (t) {
   t.plan(2)
 


### PR DESCRIPTION
Two behaviours were somewhat unexpected, both related to truncates:

In the 'getAndWatch truncate flow' test, I think we're hitting a race condition on `await this.bee.get(this.key)`, where a truncate is triggered ~at the same time as the get. This results in a `SNAPSHOT_NOT_AVAILABLE` error.
This one is solved by catching that particular error and early-returning, because we know it was triggered by a truncate, so `_onAppend` will run again anyway. But if it is indeed a race condition, I think it should be solved elsewhere in the code.

In the 'getAndWatch chaos' test, there's still a TODO, because I had to add an `await eventFlush()` to avoid a crash, and I don't think it should be necessary. It might be a similar scenario to the error above, but I'm not sure. The error is
```
`/home/hans/holepunch/hyperbee/node_modules/random-access-memory/index.js:86
      return req.callback(new Error('Could not satisfy length'), null)
                          ^

Error: Could not satisfy length
    at RAM._read (/home/hans/holepunch/hyperbee/node_modules/random-access-memory/index.js:86:27)
    at Request._run (/home/hans/holepunch/hyperbee/node_modules/random-access-storage/index.js:258:42)
    at RAM.run (/home/hans/holepunch/hyperbee/node_modules/random-access-storage/index.js:153:14)
    at RAM.read (/home/hans/holepunch/hyperbee/node_modules/random-access-storage/index.js:60:10)
    at /home/hans/holepunch/hyperbee/node_modules/hypercore/lib/merkle-tree.js:1120:13
    at new Promise (<anonymous>)
    at getStoredNode (/home/hans/holepunch/hyperbee/node_modules/hypercore/lib/merkle-tree.js:1119:10)
    at MerkleTree.get (/home/hans/holepunch/hyperbee/node_modules/hypercore/lib/merkle-tree.js:433:12)
    at MerkleTree.byteOffset (/home/hans/holepunch/hyperbee/node_modules/hypercore/lib/merkle-tree.js:763:33)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```