### PR TITLE
Add aliases for core properties, and fix update options

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,45 +184,6 @@ function cas (prev) {
 }
 ```
 
-#### `const done = db.findingPeers()`
-
-Indicate to Hyperbee that you're finding peers in the background, requests will be on hold until this is done.
-
-Call `done()` when your current discovery iteration is done, i.e. after `swarm.flush()` finishes.
-
-#### `const stream = db.replicate(isInitiatorOrStream)`
-
-Usage example:
-```js
-const swarm = new Hyperswarm()
-const done = db.findingPeers()
-swarm.on('connection', (socket) => db.replicate(socket))
-swarm.join(db.discoveryKey)
-swarm.flush().then(done, done)
-```
-
-See more about how replicate works at [core.replicate][core-replicate-docs].
-
-#### `const updated = await db.update([options])`
-
-Waits for initial proof of the new bee version until all `findingPeers` calls has finished.
-
-``` js
-const updated = await db.update()
-
-console.log('db was updated?', updated, 'version is', db.version)
-```
-
-`options` include:
-
-``` js
-{
-  wait: false
-}
-```
-
-Use `db.findingPeers()` or `{ wait: true }` to make `await db.update()` blocking.
-
 #### `const batch = db.batch()`
 
 Make a new atomic batch that is either fully processed or not processed at all.
@@ -418,5 +379,3 @@ Returns `true` if the core contains a Hyperbee, `false` otherwise.
 This requests the first block on the core, so it can throw depending on the options.
 
 `options` are the same as the `core.get` method.
-
-[core-replicate-docs]: https://github.com/holepunchto/hypercore#const-stream--corereplicateisinitiatororreplicationstream

--- a/README.md
+++ b/README.md
@@ -203,6 +203,26 @@ swarm.flush().then(done, done)
 
 See more about how replicate works at [core.replicate][core-replicate-docs].
 
+#### `const updated = await db.update([options])`
+
+Waits for initial proof of the new bee version until all `findingPeers` calls has finished.
+
+``` js
+const updated = await db.update()
+
+console.log('db was updated?', updated, 'version is', db.version)
+```
+
+`options` include:
+
+``` js
+{
+  wait: false
+}
+```
+
+Use `db.findingPeers()` or `{ wait: true }` to make `await db.update()` blocking.
+
 #### `const batch = db.batch()`
 
 Make a new atomic batch that is either fully processed or not processed at all.

--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ function cas (prev) {
 }
 ```
 
+#### `const stream = db.replicate(isInitiatorOrStream)`
+
+See more about how replicate works at [core.replicate][core-replicate-docs].
+
 #### `const batch = db.batch()`
 
 Make a new atomic batch that is either fully processed or not processed at all.
@@ -379,3 +383,5 @@ Returns `true` if the core contains a Hyperbee, `false` otherwise.
 This requests the first block on the core, so it can throw depending on the options.
 
 `options` are the same as the `core.get` method.
+
+[core-replicate-docs]: https://github.com/holepunchto/hypercore#const-stream--corereplicateisinitiatororreplicationstream

--- a/README.md
+++ b/README.md
@@ -85,6 +85,28 @@ The underlying Hypercore backing this bee.
 
 Number that indicates how many modifications were made, useful as a version identifier.
 
+#### `db.id`
+
+String containing the id (z-base-32 of the public key) identifying this bee.
+
+#### `db.key`
+
+Buffer containing the public key identifying this bee.
+
+#### `db.discoveryKey`
+
+Buffer containing a key derived from `db.key`.
+
+This discovery key does not allow you to verify the data, it's only to announce or look for peers that are sharing the same bee, without leaking the bee key.
+
+#### `db.writable`
+
+Boolean indicating if we can put or delete data in this bee.
+
+#### `db.readable`
+
+Boolean indicating if we can read from this bee. After closing the bee this will be `false`.
+
 #### `await db.put(key, [value], [options])`
 
 Insert a new key. Value can be optional.
@@ -161,6 +183,25 @@ function cas (prev) {
   return prev.value === 'can-be-deleted'
 }
 ```
+
+#### `const done = db.findingPeers()`
+
+Indicate to Hyperbee that you're finding peers in the background, requests will be on hold until this is done.
+
+Call `done()` when your current discovery iteration is done, i.e. after `swarm.flush()` finishes.
+
+#### `const stream = db.replicate(isInitiatorOrStream)`
+
+Usage example:
+```js
+const swarm = new Hyperswarm()
+const done = db.findingPeers()
+swarm.on('connection', (socket) => db.replicate(socket))
+swarm.join(db.discoveryKey)
+swarm.flush().then(done, done)
+```
+
+See more about how replicate works at [core.replicate][core-replicate-docs].
 
 #### `const batch = db.batch()`
 
@@ -357,3 +398,5 @@ Returns `true` if the core contains a Hyperbee, `false` otherwise.
 This requests the first block on the core, so it can throw depending on the options.
 
 `options` are the same as the `core.get` method.
+
+[core-replicate-docs]: https://github.com/holepunchto/hypercore#const-stream--corereplicateisinitiatororreplicationstream

--- a/index.js
+++ b/index.js
@@ -338,10 +338,6 @@ class Hyperbee extends ReadyResource {
     return this.core.readable
   }
 
-  findingPeers () {
-    return this.core.findingPeers()
-  }
-
   replicate (isInitiator, opts) {
     return this.core.replicate(isInitiator, opts)
   }

--- a/index.js
+++ b/index.js
@@ -318,6 +318,34 @@ class Hyperbee extends ReadyResource {
     return Math.max(1, this._checkout || this.core.length)
   }
 
+  get id () {
+    return this.core.id
+  }
+
+  get key () {
+    return this.core.key
+  }
+
+  get discoveryKey () {
+    return this.core.discoveryKey
+  }
+
+  get writable () {
+    return this.core.writable
+  }
+
+  get readable () {
+    return this.core.readable
+  }
+
+  findingPeers () {
+    return this.core.findingPeers()
+  }
+
+  replicate (isInitiator, opts) {
+    return this.core.replicate(isInitiator, opts)
+  }
+
   update () {
     return this.core.update({ ifAvailable: true, hash: false })
   }

--- a/index.js
+++ b/index.js
@@ -346,8 +346,8 @@ class Hyperbee extends ReadyResource {
     return this.core.replicate(isInitiator, opts)
   }
 
-  update () {
-    return this.core.update({ ifAvailable: true, hash: false })
+  update (opts) {
+    return this.core.update(opts)
   }
 
   peek (range, opts) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -4,6 +4,32 @@ const { create, collect, createCore } = require('./helpers')
 
 const Hyperbee = require('..')
 
+test('basic properties', async function (t) {
+  const db = create()
+
+  t.is(typeof db.findingPeers, 'function')
+  t.is(typeof db.replicate, 'function')
+
+  t.is(db.id, null)
+  t.is(db.key, null)
+  t.is(db.discoveryKey, null)
+
+  t.is(db.writable, false)
+  t.is(db.readable, true)
+
+  await db.ready()
+
+  t.is(db.writable, true)
+
+  t.is(db.id.length, 52)
+  t.is(db.key.byteLength, 32)
+  t.is(db.discoveryKey.byteLength, 32)
+
+  t.is(db.id, db.core.id)
+  t.is(db.key, db.core.key)
+  t.is(db.discoveryKey, db.core.discoveryKey)
+})
+
 test('out of bounds iterator', async function (t) {
   const db = create()
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -7,7 +7,6 @@ const Hyperbee = require('..')
 test('basic properties', async function (t) {
   const db = create()
 
-  t.is(typeof db.findingPeers, 'function')
   t.is(typeof db.replicate, 'function')
 
   t.is(db.id, null)


### PR DESCRIPTION
If you're using a Hyperbee then there should be no need to constantly access to `db.core`

Yes, they're just core aliases but makes the bee experience better

Closes https://github.com/holepunchto/hyperbee/issues/128