### PR TITLE
Fix checkout with reuseSessions bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -455,7 +455,7 @@ class Hyperbee extends ReadyResource {
     // same as above, just checkout isn't set yet...
 
     const snap = opts.reuseSession
-      ? this
+      ? this.core
       : version <= this.core.length ? this.core.snapshot() : this.core.session()
 
     return new Hyperbee(snap, {


### PR DESCRIPTION
If `reuseSessions` is currently set, it'll create a new Hyperbee with a Hyperbee as the first arg.