### PR TITLE
isHyperbee: no safetyCatch on failed decode

### DIFF
--- a/index.js
+++ b/index.js
@@ -611,7 +611,6 @@ class Hyperbee extends ReadyResource {
     try {
       return Header.decode(blk0).protocol === 'hyperbee'
     } catch (err) { // undecodable
-      safetyCatch(err)
       return false
     }
   }


### PR DESCRIPTION
`Header.decode` can throw RangeErrors because of varint (https://github.com/chrisdickinson/varint/blob/7fc8829334c20c4c0e246e3b473c1eb1c03ebbf9/decode.js#L17). RangeErrors get thrown by safetyCatch, so we need to ignore all errors here