### PR TITLE
Add onchange as a watch option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1250,14 +1250,14 @@ class Watcher extends ReadyResource {
         })
 
         if (this.current.core.fork !== this.previous.core.fork) {
-          return this._yield()
+          return await this._yield()
         }
 
         this.stream = this._differ(this.current, this.previous, this.range)
 
         try {
           for await (const data of this.stream) { // eslint-disable-line
-            return this._yield()
+            return await this._yield()
           }
         } finally {
           this.stream = null


### PR DESCRIPTION
Adds support for an `onchange` callback to the `Watcher`

Depends on https://github.com/holepunchto/hyperbee/pull/138