### PR TITLE
(WIP) Experimental "Lite" Watcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "protocol-buffers-encodings": "^1.2.0",
     "ready-resource": "^1.0.0",
     "safety-catch": "^1.0.2",
+    "signal-promise": "^1.0.3",
     "streamx": "^2.12.4",
     "xache": "^1.2.1"
   },


### PR DESCRIPTION
The default watcher creates tons of diff streams on every `_next` call, which can affect perf. This PR adds a "lite" watcher that doesn't diff. Instead it manually checks the last N blocks, if N is small, and always triggers on larger updates or truncations.

Also changes the API, so lite watchers should only be used with the `onchange` option.