### PR TITLE
Use unslab to simplify copyEntry + add test

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "ready-resource": "^1.0.0",
     "safety-catch": "^1.0.2",
     "streamx": "^2.12.4",
-    "unslab": "hdegroote/unslab#copy-nulls",
+    "unslab": "^1.2.0",
     "xache": "^1.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "ready-resource": "^1.0.0",
     "safety-catch": "^1.0.2",
     "streamx": "^2.12.4",
+    "unslab": "hdegroote/unslab#copy-nulls",
     "xache": "^1.2.1"
   },
   "devDependencies": {
@@ -27,6 +28,7 @@
     "random-access-memory": "^6.0.0",
     "standard": "^17.0.0",
     "sub-encoder": "^1.0.6",
+    "test-tmp": "^1.2.1",
     "tree-to-string": "^1.1.1"
   },
   "scripts": {

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,0 +1,28 @@
+const test = require('brittle')
+const b4a = require('b4a')
+const Hypercore = require('hypercore')
+const makeTmpDir = require('test-tmp')
+
+const Hyperbee = require('../index')
+
+test('entries are not cached using buffers from default slab', async function (t) {
+  const dir = await makeTmpDir(t)
+
+  const core = new Hypercore(dir)
+  const db = new Hyperbee(core)
+
+  await db.put(b4a.from('smallKey'), b4a.from('smallValue'))
+
+  const entry = await db.get('smallKey')
+  console.log(entry.key.buffer.byteLength, entry.value.buffer.byteLength)
+  t.is(
+    entry.key.buffer.byteLength < 100,
+    true,
+    'Uses a small slab for cached key entry'
+  )
+  t.is(
+    entry.value.buffer.byteLength < 100,
+    true,
+    'Uses a small slab for cached value entry'
+  )
+})


### PR DESCRIPTION
Draft because it relies on https://github.com/holepunchto/unslab/pull/1

(can also work without above PR, but then hyperbee needs to special-case the null entries before calling unslab)