### PR TITLE
Derive node and key cache from shared rache

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ Make a new Hyperbee instance. `core` should be a [Hypercore](https://github.com/
 ```js
 {
   keyEncoding: 'binary', // "binary" (default), "utf-8", "ascii", "json", or an abstract-encoding
-  valueEncoding: 'binary', // Same options as keyEncoding like "json", etc
-  maxCacheSize: 65536 // Max size of the key and node cache
+  valueEncoding: 'binary' // Same options as keyEncoding like "json", etc
 }
 ```
 
@@ -107,10 +106,6 @@ Boolean indicating if we can put or delete data in this bee.
 #### `db.readable`
 
 Boolean indicating if we can read from this bee. After closing the bee this will be `false`.
-
-#### `db.maxCacheSize`
-
-Integer indicating the max size of the caches (both the node and the key cache).
 
 #### `await db.put(key, [value], [options])`
 

--- a/index.js
+++ b/index.js
@@ -388,9 +388,8 @@ class Hyperbee extends ReadyResource {
     this._entryWatchers = this._onappendBound ? [] : null
     this._sessions = opts.sessions !== false
 
-    // sub from existing rache if any passed in
-    this._keyCache = new Cache(Rache.from(this.core.globalCache))
-    this._nodeCache = new Cache(Rache.from(this._keyCache))
+    this._keyCache = null
+    this._nodeCache = null
 
     this._batches = []
 
@@ -404,8 +403,12 @@ class Hyperbee extends ReadyResource {
     }
   }
 
-  _open () {
-    return this.core.ready()
+  async _open () {
+    await this.core.ready()
+
+    const baseCache = Rache.from(this.core.globalCache)
+    this._keyCache = new Cache(baseCache)
+    this._nodeCache = new Cache(Rache.from(baseCache))
   }
 
   get version () {

--- a/index.js
+++ b/index.js
@@ -598,8 +598,7 @@ class Hyperbee extends ReadyResource {
       checkout: version,
       keyEncoding: opts.keyEncoding || this.keyEncoding,
       valueEncoding: opts.valueEncoding || this.valueEncoding,
-      extension: this.extension !== null ? this.extension : false,
-      cache: this._keyCache // Used to sub from
+      extension: this.extension !== null ? this.extension : false
     })
   }
 

--- a/index.js
+++ b/index.js
@@ -389,9 +389,8 @@ class Hyperbee extends ReadyResource {
     this._sessions = opts.sessions !== false
 
     // sub from existing rache if any passed in
-    const baseCache = Rache.from(opts.cache)
-    this._keyCache = new Cache(baseCache)
-    this._nodeCache = new Cache(Rache.from(baseCache))
+    this._keyCache = new Cache(Rache.from(this.core.globalCache))
+    this._nodeCache = new Cache(Rache.from(this._keyCache))
 
     this._batches = []
 

--- a/index.js
+++ b/index.js
@@ -435,11 +435,6 @@ class Hyperbee extends ReadyResource {
     return this.core.readable
   }
 
-  get maxCacheSize () {
-    // Note: the key cache and the node cache have the same size
-    return this._keyCache.keys.maxSize
-  }
-
   replicate (isInitiator, opts) {
     return this.core.replicate(isInitiator, opts)
   }

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ const b4a = require('b4a')
 const safetyCatch = require('safety-catch')
 const ReadyResource = require('ready-resource')
 const debounce = require('debounceify')
-const Xache = require('xache')
+const Rache = require('rache')
+
 const { all: unslabAll } = require('unslab')
 
 const RangeIterator = require('./iterators/range')
@@ -38,8 +39,8 @@ class Child {
 }
 
 class Cache {
-  constructor (maxSize) {
-    this.keys = new Xache({ maxSize })
+  constructor (rache) {
+    this.keys = rache
     this.length = 0
   }
 
@@ -387,9 +388,10 @@ class Hyperbee extends ReadyResource {
     this._entryWatchers = this._onappendBound ? [] : null
     this._sessions = opts.sessions !== false
 
-    const maxCacheSize = opts.maxCacheSize || 65536
-    this._keyCache = new Cache(maxCacheSize)
-    this._nodeCache = new Cache(maxCacheSize)
+    // sub from existing rache if any passed in
+    const baseCache = Rache.from(opts.cache)
+    this._keyCache = new Cache(baseCache)
+    this._nodeCache = new Cache(Rache.from(baseCache))
 
     this._batches = []
 
@@ -599,7 +601,8 @@ class Hyperbee extends ReadyResource {
       checkout: version,
       keyEncoding: opts.keyEncoding || this.keyEncoding,
       valueEncoding: opts.valueEncoding || this.valueEncoding,
-      extension: this.extension !== null ? this.extension : false
+      extension: this.extension !== null ? this.extension : false,
+      cache: this._keyCache // Used to sub from
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "hypercore-errors": "^1.0.0",
     "mutexify": "^1.4.0",
     "protocol-buffers-encodings": "^1.2.0",
-    "rache": "^0.0.3",
+    "rache": "^1.0.0",
     "ready-resource": "^1.0.0",
     "safety-catch": "^1.0.2",
     "streamx": "^2.12.4",
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "brittle": "^3.1.0",
-    "hypercore": "^10.18.0",
+    "hypercore": "holepunchto/hypercore#rache-global-approach",
     "protocol-buffers": "^4.2.0",
     "random-access-memory": "^6.0.0",
     "standard": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "brittle": "^3.1.0",
-    "hypercore": "holepunchto/hypercore#rache-global-approach",
+    "hypercore": "^10.37.10",
     "protocol-buffers": "^4.2.0",
     "random-access-memory": "^6.0.0",
     "standard": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
     "hypercore-errors": "^1.0.0",
     "mutexify": "^1.4.0",
     "protocol-buffers-encodings": "^1.2.0",
+    "rache": "^0.0.3",
     "ready-resource": "^1.0.0",
     "safety-catch": "^1.0.2",
     "streamx": "^2.12.4",
-    "unslab": "^1.2.0",
-    "xache": "^1.2.1"
+    "unslab": "^1.2.0"
   },
   "devDependencies": {
     "brittle": "^3.1.0",

--- a/test/cache.js
+++ b/test/cache.js
@@ -34,7 +34,6 @@ test('entries are not cached using buffers from default slab', async function (t
 test('node and key caches are subbed from a passed-in rache', async t => {
   const globalCache = new Rache()
   const core = new Hypercore(RAM, { globalCache })
-  console.log('core has', core.globalCache)
   const db = new Hyperbee(core)
 
   t.is(globalCache.globalSize, 0, 'sanity check')
@@ -44,19 +43,4 @@ test('node and key caches are subbed from a passed-in rache', async t => {
   // TODO: for some reason, there's only 1 cache entry
   // total after a put+get, which seems off. Investigate.
   t.is(globalCache.globalSize > 0, true, 'subbed from globalCache')
-})
-
-test('node and key caches are derived from the same rache instance', async t => {
-  const core = new Hypercore(RAM)
-  const db = new Hyperbee(core)
-  await db.ready()
-
-  // Note: not an ideal test, since it accesses private props,
-  //   and sets something nonsensical on the cache
-  // These caches currently aren't passed down
-  //   to sessions and checkouts, which create their own new cache
-  //   so we can't indirectly put an element in them to verify they're linked
-  //  (hence the hack of directly setting something in the cache)
-  db._keyCache.keys.set('some', 'thing')
-  t.is(db._nodeCache.keys.globalSize, 1, 'caches are globally linked')
 })

--- a/test/cache.js
+++ b/test/cache.js
@@ -2,7 +2,7 @@ const test = require('brittle')
 const b4a = require('b4a')
 const Hypercore = require('hypercore')
 const makeTmpDir = require('test-tmp')
-const RAM = require('random-access-memory')
+// const RAM = require('random-access-memory')
 
 const Hyperbee = require('../index')
 
@@ -30,7 +30,7 @@ test('entries are not cached using buffers from default slab', async function (t
   await db.close()
 })
 
-test('maxCacheSize arg can be set', async function (t) {
+/* test('maxCacheSize arg can be set', async function (t) {
   const core = new Hypercore(RAM.reusable())
   const db = new Hyperbee(core, { maxCacheSize: 10 })
 
@@ -42,4 +42,4 @@ test('default maxCacheSize', async function (t) {
   const db = new Hyperbee(core)
 
   t.is(db.maxCacheSize, 65536, 'Correct max cache size')
-})
+}) */


### PR DESCRIPTION
Depends on https://github.com/holepunchto/hypercore/pull/535 for it to really make sense

This makes the node- and key cache derive from the same rache.

It removes the `maxCacheSize` opt, which is made redundant (technically a breaking change, but very recently added, and passing it in anyway won't cause any issues).

Note: this PR changes the ready flow (the caches can now only be set after `this.core` is ready). Using the caches before the bee is ready doesn't make sense, so that should be fine.

The flow when a `globalCache` is set on the underlying `Hypercore` makes sense: all caches along all sessions then derive from the same `globalCache`.

But when no `globalCache` was set on the hypercore, each checkout/session will still create its own separate caches. This doesn't really make sense. It could be solved by passing a `globalCache` object through when creating a new session. I didn't do that for now, because in the end it's the same behaviour as before (and the main focus of this PR is on the case where a `globalCache` is used).
