### PR TITLE
Remove RAM usage in README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ npm install hyperbee
 ```js
 const Hyperbee = require('hyperbee')
 const Hypercore = require('hypercore')
-const RAM = require('random-access-memory')
 
-const core = new Hypercore(RAM)
+const core = new Hypercore('./storage')
 const db = new Hyperbee(core, { keyEncoding: 'utf-8', valueEncoding: 'binary' })
 
 // If you own the core


### PR DESCRIPTION
Hypercore storage no longer supports `random-access-memory` and other `random-access-storage` instances.