### PR TITLE
Avoid uncaught promises by awaiting multiple in objs

### DIFF
--- a/iterators/diff.js
+++ b/iterators/diff.js
@@ -195,7 +195,13 @@ module.exports = class DiffIterator {
       }
 
       if (l.isKey && r.isKey) {
-        if (c === 0) return { left: await a.nextKey(), right: await b.nextKey() }
+        if (c === 0) {
+          const [left, right] = await Promise.all([
+            a.nextKey(),
+            b.nextKey()
+          ])
+          return { left, right }
+        }
         if (c < 0) return { left: await a.nextKey(), right: null }
         return { left: null, right: await b.nextKey() }
       }


### PR DESCRIPTION
The following illustrates how this can occur:

```js
async function test () {
  const prom1 = new Promise((resolve) => setTimeout(resolve, 100))
  const prom2 = Promise.reject(Error('whoops'))

  return {
    a: await prom1,
    b: await prom2
  }
}

test().catch(() => console.log('catch'))
```

The `whoops` will reject before `prom1` is awaited causing it to be uncaught.