### PR TITLE
Remove bitfield check in `TreeNode` `preload`

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,19 +149,18 @@ class TreeNode {
     const core = getBackingCore(this.block.tree.core)
     if (!core) return
 
-    const bitfield = core.core.bitfield
     const blocks = []
 
     for (let i = 0; i < this.keys.length; i++) {
       const k = this.keys[i]
       if (k.value) continue
-      if (k.seq >= core.signedLength || (bitfield && bitfield.get(k.seq))) continue
+      if (k.seq >= core.signedLength) continue
       blocks.push(k.seq)
     }
     for (let i = 0; i < this.children.length; i++) {
       const c = this.children[i]
       if (c.value) continue
-      if (c.seq >= core.signedLength || (bitfield && bitfield.get(c.seq))) continue
+      if (c.seq >= core.signedLength) continue
       blocks.push(c.seq)
     }
 


### PR DESCRIPTION
The check will be performed in the core's `download()` regardless. The array of blocks are added as a range to the replicator which checks and compresses the range here:
https://github.com/holepunchto/hypercore/blob/125aa810b54ff916f5b55cc21e3c17efb0b7ca5a/lib/replicator.js#L2668-L2669