### PR TITLE
Clarify arguments in README.md for cas option

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ If you're inserting a series of data atomically or want more performance then ch
 
 By returning `true` it will insert the value, otherwise it won't.
 
-It receives two args: `prev` is the current node entry, and `next` is the potential new node.
+It receives two args: `prev` is the current node entry, and `next` is the potential new node at the specified key.
 
 ```js
 await db.put('number', '123', { cas })
@@ -170,7 +170,7 @@ Delete a key.
 
 By returning `true` it will delete the value, otherwise it won't.
 
-It only receives one arg: `prev` which is the current node entry.
+It receives one argument: `prev` - the current node entry at the specified key being deleted.
 
 ```js
 // This won't get deleted


### PR DESCRIPTION
The cas function always checks for the specified key and not the whole b-tree.

Theoretically it doesn't need this clarification, practically for new comers (like me), this clarification removes some fuzziness from the picture in the brain immediately. 

Nobody needs to think what "current node" does actually mean, in the moment we push data to a db. 
Since how can there be a "current node" in that moment? 

In the previous doc version, "current node" is defined by the key - so that becomes clearer now.
When talking of DHTs and b-tree, it's clear we are talking about nodes in the end.

Also I am wondering if there's another clarification necessary what prev, next contains! Does contain the full structure of seq, key, value - or just the key or maybe just the value? Naturally it is intuitive to say "well it is probabably be the whole structure", but still it requires more in thinking and guessing and interpretation of the examples.