### PR TITLE
Document cas behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ By returning `true` it will insert the value, otherwise it won't.
 
 It receives two args: `prev` is the current node entry, and `next` is the potential new node.
 
+It executes only if a previous value exists. For a new or deleted key, the value is inserted without calling `cas`.
+
 ```js
 await db.put('number', '123', { cas })
 console.log(await db.get('number')) // => { seq: 1, key: 'number', value: '123' }
@@ -171,6 +173,8 @@ Delete a key.
 By returning `true` it will delete the value, otherwise it won't.
 
 It only receives one arg: `prev` which is the current node entry.
+
+It executes only if the key exists. If there is no key to delete, the deletion succeeds without calling `cas`.
 
 ```js
 // This won't get deleted

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ By returning `true` it will insert the value, otherwise it won't.
 
 It receives two args: `prev` is the current node entry, and `next` is the potential new node.
 
-It executes only if a previous value exists. For a new or deleted key, the value is inserted without calling `cas`.
+It executes only if a previous key exists. For a new or deleted key, the value is inserted without calling `cas`.
 
 ```js
 await db.put('number', '123', { cas })

--- a/test/cas.js
+++ b/test/cas.js
@@ -2,7 +2,7 @@ const test = require('brittle')
 const b4a = require('b4a')
 const { create } = require('./helpers')
 
-test('bee.put({ cas }) succeds if cas(last, next) returns truthy', async function (t) {
+test('bee.put({ cas }) succeeds if cas(last, next) returns truthy', async function (t) {
   const key = 'key'
   const value = 'value'
 
@@ -99,7 +99,40 @@ test('bee.put({ cas }) succeds if cas(last, next) returns truthy', async functio
   }
 })
 
-test('bee.batch().put({ cas }) succeds if cas(last, next) returns truthy', async function (t) {
+test('bee.put({ cas }) ignores cas(last, next) if it is a new key', async function (t) {
+  const key = 'key'
+  const value = 'value'
+
+  {
+    const db = await create(t)
+    const cas = () => false
+    await db.put(key, value, { cas })
+    const fst = await db.get(key)
+    t.not(fst, null)
+  }
+
+  {
+    const db = await create(t)
+    const cas = () => false
+    await db.put(key, value, { cas })
+    const fst = await db.get(key)
+    await db.put(key, value + '^', { cas })
+    const snd = await db.get(key)
+    t.alike(fst, snd)
+  }
+
+  {
+    const db = await create(t)
+    const cas = () => false
+    await db.put(key, value)
+    await db.del(key)
+    await db.put(key, value, { cas })
+    const fst = await db.get(key)
+    t.not(fst, null)
+  }
+})
+
+test('bee.batch().put({ cas }) succeeds if cas(last, next) returns truthy', async function (t) {
   const key = 'key'
   const value = 'value'
 
@@ -212,7 +245,7 @@ test('bee.batch().put({ cas }) succeds if cas(last, next) returns truthy', async
   }
 })
 
-test('bee.del({ cas }) succeds if cas(last, tomb) returns truthy', async function (t) {
+test('bee.del({ cas }) succeeds if cas(last, tomb) returns truthy', async function (t) {
   const key = 'key'
   const value = 'value'
 
@@ -341,7 +374,35 @@ test('bee.del({ cas }) succeds if cas(last, tomb) returns truthy', async functio
   }
 })
 
-test('bee.batch({ cas }) succeds if cas(last, tomb) returns truthy', async function (t) {
+test('bee.del({ cas }) ignores cas(last, tomb) if key does not exist', async function (t) {
+  const key = 'key'
+  const value = 'value'
+
+  {
+    const db = await create(t)
+    let isCasCalled = false
+    const cas = (lst) => {
+      isCasCalled = true
+      return true
+    }
+    await db.del(key, { cas })
+    t.is(isCasCalled, false)
+  }
+
+  {
+    const db = await create(t)
+    let isCasCalled = false
+    const cas = (lst) => {
+      isCasCalled = true
+      return lst.value === value
+    }
+    await db.put(key, value)
+    await db.del(key, { cas })
+    t.is(isCasCalled, true)
+  }
+})
+
+test('bee.batch({ cas }) succeeds if cas(last, tomb) returns truthy', async function (t) {
   const key = 'key'
   const value = 'value'
 


### PR DESCRIPTION
Added documentation and test cases regarding 'cas' not being called if the key does not exist.

If the current behavior is a bug, then fixing it would be a breaking change.
If it's a feature, then just need proper documentation so it's clear.

If I'm not mistaken, this is the part where keys can be inserted without cas being called:
https://github.com/holepunchto/hyperbee/blob/012caaf19bbae644f43eb8cabea87c03fc6101a5/index.js#L198-L201

The current behavior is now explicitly tested.

For local reproduction you can aslo use this:

```js
const Corestore = require('corestore')
const Hyperbee = require('hyperbee')

const store = new Corestore('corestore-bug')
const core = store.get({ name: 'cas-store' })
const db = new Hyperbee(core, { keyEncoding: 'utf-8', valueEncoding: 'utf-8' })

const cas = (prev, next) => {
    console.log('CAS hit')
    return true
}

const sharedKey = Date.now()

function put(key = sharedKey, opts = { cas }) {
    console.log(`PUT [${key}]  --> 'value'`)
    return db.put(key, 'value', opts)
}

function del(key = sharedKey) {
    console.log(`DEL [${key}]`)
    return db.del(key, { cas })
}

async function run() {
    // put initial
    await put()
    // put on same key
    await put()
    // delete
    await del()
    // delete already deleted
    await del()
    // put after deletion
    await put()
    // put again
    await put()

    console.log()
    console.log('Try PUT new key with cas that always returns false')
    const newKey = Date.now()
    console.log('Before', newKey, '-->', await db.get(newKey))
    await put(newKey, { cas: (prev, next) => false })
    console.log('After', newKey, '-->', await db.get(newKey))

}

run()
```
which results in:
```
PUT [1772519075697]  --> 'value'
PUT [1772519075697]  --> 'value'
CAS hit
DEL [1772519075697]
CAS hit
DEL [1772519075697]
PUT [1772519075697]  --> 'value'
PUT [1772519075697]  --> 'value'
CAS hit

Try PUT new key with cas that always returns false
Before 1772519075744 --> null
PUT [1772519075744]  --> 'value'
After 1772519075744 --> { seq: 136, key: '1772519075744', value: 'value' }
```