### PR TITLE
Add `disableCache` opt & guard against caches being null when disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Make a new Hyperbee instance. `core` should be a [Hypercore](https://github.com/
 ```js
 {
   keyEncoding: 'binary', // "binary" (default), "utf-8", "ascii", "json", or an abstract-encoding
-  valueEncoding: 'binary' // Same options as keyEncoding like "json", etc
+  valueEncoding: 'binary', // Same options as keyEncoding like "json", etc
   disableCache: false // Whether to disable caching. Caching is enabled by default.
 }
 ```

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Make a new Hyperbee instance. `core` should be a [Hypercore](https://github.com/
 {
   keyEncoding: 'binary', // "binary" (default), "utf-8", "ascii", "json", or an abstract-encoding
   valueEncoding: 'binary' // Same options as keyEncoding like "json", etc
+  disableCache: false // Whether to disable caching. Caching is enabled by default.
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -941,8 +941,9 @@ class Batch {
           : null
       if (k !== null) return k
       const key = (await this._getBlock(seq)).key
-      if (this.core.fork === this.tree.core.fork && this.tree._keyCache !== null)
+      if (this.core.fork === this.tree.core.fork && this.tree._keyCache !== null) {
         this.tree._keyCache.set(seq, key)
+      }
       return key
     } finally {
       this.tree._cacheLock.exit(seq)

--- a/index.js
+++ b/index.js
@@ -431,6 +431,7 @@ class Hyperbee extends ReadyResource {
     this._entryWatchers = this._onappendBound ? [] : null
     this._sessions = opts.sessions !== false
 
+    this._disableCache = opts.disableCache === true
     this._keyCache = null
     this._nodeCache = null
     this._cacheLock = new CacheLock()
@@ -460,8 +461,8 @@ class Hyperbee extends ReadyResource {
     if (this._checkout === -1) this._checkout = Math.max(1, this.core.length)
 
     const baseCache = Rache.from(this.core.globalCache)
-    this._keyCache = new Cache(baseCache)
-    this._nodeCache = new Cache(Rache.from(baseCache))
+    this._keyCache = this._disableCache ? null : new Cache(baseCache)
+    this._nodeCache = this._disableCache ? null : new Cache(Rache.from(baseCache))
   }
 
   get version() {
@@ -696,8 +697,8 @@ class Hyperbee extends ReadyResource {
       watcher._ontruncate()
     }
 
-    this._nodeCache.gc(length)
-    this._keyCache.gc(length)
+    if (this._nodeCache) this._nodeCache.gc(length)
+    if (this._keyCache) this._keyCache.gc(length)
   }
 
   _makeSnapshot() {
@@ -777,6 +778,7 @@ class Hyperbee extends ReadyResource {
       sep: this.sep,
       lock: this.lock,
       checkout: version,
+      disableCache: this._disableCache,
       keyEncoding: opts.keyEncoding || this.keyEncoding,
       valueEncoding: opts.valueEncoding || this.valueEncoding,
       extension: this.extension !== null ? this.extension : false
@@ -806,6 +808,7 @@ class Hyperbee extends ReadyResource {
       sep: this.sep,
       lock: this.lock,
       checkout: this._checkout,
+      disableCache: this._disableCache,
       valueEncoding,
       keyEncoding,
       extension: this.extension !== null ? this.extension : false,
@@ -932,10 +935,10 @@ class Batch {
     await this.tree._cacheLock.enter(seq)
 
     try {
-      const k = this.core.fork === this.tree.core.fork ? this.tree._keyCache.get(seq) : null
+      const k = this.core.fork === this.tree.core.fork && this.tree._keyCache !== null ? this.tree._keyCache.get(seq) : null
       if (k !== null) return k
       const key = (await this._getBlock(seq)).key
-      if (this.core.fork === this.tree.core.fork) this.tree._keyCache.set(seq, key)
+      if (this.core.fork === this.tree.core.fork && this.tree._keyCache !== null) this.tree._keyCache.set(seq, key)
       return key
     } finally {
       this.tree._cacheLock.exit(seq)

--- a/index.js
+++ b/index.js
@@ -935,10 +935,14 @@ class Batch {
     await this.tree._cacheLock.enter(seq)
 
     try {
-      const k = this.core.fork === this.tree.core.fork && this.tree._keyCache !== null ? this.tree._keyCache.get(seq) : null
+      const k =
+        this.core.fork === this.tree.core.fork && this.tree._keyCache !== null
+          ? this.tree._keyCache.get(seq)
+          : null
       if (k !== null) return k
       const key = (await this._getBlock(seq)).key
-      if (this.core.fork === this.tree.core.fork && this.tree._keyCache !== null) this.tree._keyCache.set(seq, key)
+      if (this.core.fork === this.tree.core.fork && this.tree._keyCache !== null)
+        this.tree._keyCache.set(seq, key)
       return key
     } finally {
       this.tree._cacheLock.exit(seq)

--- a/test/cache.js
+++ b/test/cache.js
@@ -36,3 +36,37 @@ test('node and key caches are subbed from a passed-in rache', async (t) => {
 
   await db.close()
 })
+
+test('disableCache', async (t) => {
+  // Plan assertions for onseq:
+  // 2 normal gets, 1 for the 2nd put to get root, 2 get w/ two layers, 1 for put
+  const onseqAsserts = 2 + 1 + 2 + 1
+  t.plan(onseqAsserts + 4)
+  const core = new Hypercore(await t.tmp(), { onseq: () => {
+    t.pass('called onseq') // Onseq only is called when get is called
+  } })
+  const db = new Hyperbee(core, { disableCache: true })
+  await db.ready()
+
+  t.ok(db._disableCache, 'opt sets internal prop')
+
+  await db.put('some', 'thing')
+  await db.get('some') // onseq +1
+  await db.get('some') // onseq +1
+
+  const preLength = db.core.length // setup for truncation
+
+  await db.put('no', 'thing') // onseq +1
+  await t.execution(db.get('foo'), 'ensure getKey() works w/o cache') // onseq +2
+
+  // Because caches are gc'ed when truncating
+  await t.execution(db.core.truncate(preLength), 'truncation supports no caches')
+
+  await db.put('new', 'value') // onseq +1
+
+  const prev = db.checkout(preLength + 1)
+  t.ok(prev._disableCache, 'internal prop is inherited')
+  
+  await prev.close()
+  await db.close()
+})

--- a/test/cache.js
+++ b/test/cache.js
@@ -42,9 +42,11 @@ test('disableCache', async (t) => {
   // 2 normal gets, 1 for the 2nd put to get root, 2 get w/ two layers, 1 for put
   const onseqAsserts = 2 + 1 + 2 + 1
   t.plan(onseqAsserts + 4)
-  const core = new Hypercore(await t.tmp(), { onseq: () => {
-    t.pass('called onseq') // Onseq only is called when get is called
-  } })
+  const core = new Hypercore(await t.tmp(), {
+    onseq: () => {
+      t.pass('called onseq') // Onseq only is called when get is called
+    }
+  })
   const db = new Hyperbee(core, { disableCache: true })
   await db.ready()
 
@@ -66,7 +68,7 @@ test('disableCache', async (t) => {
 
   const prev = db.checkout(preLength + 1)
   t.ok(prev._disableCache, 'internal prop is inherited')
-  
+
   await prev.close()
   await db.close()
 })


### PR DESCRIPTION
An option to disable caching in the `Hyperbee` instance. Helpful for supporting mark & sweep pattern in hypercore as the cache can skip `.get()` calls for blocks.

Added a test for hitting all the cases where previously no check on the cache being non-null was in place because they were assumed to be only post `_open()` (truncating & getting keys).

This does not disable the block map in `Batch` assuming that caching blocks within a batch is a discrete operation and doesn't mean the next operation would load from the cache.